### PR TITLE
Add missing proxy config to client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,5 +23,6 @@
     "eslint-plugin-prettier": "^2.6.2",
     "prettier": "^1.14.2",
     "prettier-eslint": "^8.8.2"
-  }
+  },
+  "proxy": "http://localhost:4000"
 }


### PR DESCRIPTION
This allows React to work locally in local dev by proxying api calls to / to the server running on localhost:4000